### PR TITLE
feat: linux gpu support and upgrade to torch 2.9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
 # PyTorch: CPU wheels for non-Windows
-torch==2.4.1; platform_system != "Windows"
+torch==2.9.1; platform_system != "Windows"
 
 # PyTorch for Windows via DirectML backend
 torch-directml; platform_system == "Windows"

--- a/trainermin.py
+++ b/trainermin.py
@@ -46,11 +46,8 @@ TRAINING = True
 # Optimized alignment parameters
 WIN_SIZE_MUL = 10  # Window size multiplier for perfect accuracy
 
-DEVICE = "mps" if torch.backends.mps.is_available() else "cuda" if torch.cuda.is_available() else "cpu"
-
-DEVICE = "cpu"
-
-if DEVICE != "mps" and DEVICE != "cuda" and sys.platform == 'win32':
+DEVICE = None
+if sys.platform == 'win32':
     try:
         import torch_directml
         import time
@@ -87,7 +84,18 @@ if DEVICE != "mps" and DEVICE != "cuda" and sys.platform == 'win32':
 
     except:
         DEVICE = "cpu"
-
+elif sys.platform == "darwin":
+    # Apple. TODO: verify this works.
+    if torch.backends.mps.is_available():
+        DEVICE = torch.device("mps")
+elif sys.platform.startswith("linux"):
+    # Linux. Assume no DirectML, just use whatever is available.
+    if torch.cuda.is_available():
+        # This also may include ROCm, it's just opaque.
+        DEVICE = torch.device("cuda")
+# Fall back to CPU
+if DEVICE is None:
+    DEVICE = torch.device("cpu")
 
 class MicroChad(nn.Module):
     def __init__(self):

--- a/trainermin.py
+++ b/trainermin.py
@@ -1474,7 +1474,7 @@ def main():
         dummy_input,
         sys.argv[2],
         export_params=True,
-        opset_version=15,
+        opset_version=18,
         do_constant_folding=True,
         input_names=['input'],
         output_names=['output'],

--- a/trainermin.py
+++ b/trainermin.py
@@ -1,3 +1,23 @@
+# First check environment variables
+import os
+from pathlib import Path
+
+# We want to store the temporary '.pth'-files somewhere before we can
+# merge them later. Usually it's fine to put it next to the binary but
+# some setups may want to overwrite this. E.g. the binary is stored 
+# in a immutable location.
+#
+# TODO: Figure out a better default location. Using /lib or /bin, when
+# e.g. installing this as a system package, is bad and doesn't follow
+# the Linux FHS. We also need to take windows into consideration.
+tmp_dir = Path(os.environ.get('BABBLE_TRAINER_TMP_DIR', '.'))
+
+# We assume the 'baseline_*.pth'-files are near the executable. In some 
+# cases, e.g. when running from the command line, this is not always the
+# case, so let's load it from environment. 
+baseline_dir = Path(os.environ.get('BABBLE_TRAINER_BASELINE_DIR', '.'))
+
+# Continue importing rest of depedencies
 import torch
 import torch.nn as nn
 import torch.optim as optim
@@ -1343,9 +1363,9 @@ def main():
     print(model_L, flush=True)
     print(model_R, flush=True)
 
-    model_L.load_state_dict(torch.load("baseline_L.pth", map_location="cpu", weights_only=False))
+    model_L.load_state_dict(torch.load(baseline_dir.joinpath("baseline_L.pth"), map_location="cpu", weights_only=False))
     model_L.to(DEVICE)
-    model_R.load_state_dict(torch.load("baseline_R.pth", map_location="cpu", weights_only=False))
+    model_R.load_state_dict(torch.load(baseline_dir.joinpath("baseline_R.pth"), map_location="cpu", weights_only=False))
     model_R.to(DEVICE)
     trained_model_L = model_L
     trained_model_R = model_R
@@ -1428,8 +1448,8 @@ def main():
     # Save the final model
     #torch.save(trained_model.state_dict(), "final_model_temporal_que_tuned_2.pth")
     
-    torch.save(trained_model_L.state_dict(), "left_tuned.pth")
-    torch.save(trained_model_R.state_dict(), "right_tuned.pth")
+    torch.save(trained_model_L.state_dict(), tmp_dir.joinpath("left_tuned.pth"))
+    torch.save(trained_model_R.state_dict(), tmp_dir.joinpath("right_tuned.pth"))
 
     multi = MultiChad()
     multi.left.load_state_dict(trained_model_L.state_dict())

--- a/trainermin.py
+++ b/trainermin.py
@@ -1497,7 +1497,9 @@ def main():
         dynamic_axes={
             'input': {0: 'batch_size'},
             'output': {0: 'batch_size'}
-        }
+        },
+        dynamo=True,
+        external_data=False
     )
     print("Model exported to ONNX: " + sys.argv[2], flush=True)
 


### PR DESCRIPTION
These are some fixes I had to do to get everything working on Linux with latest torch version. 

If not all of these changes are wanted, feel free to just cherry-pick & modify.

Linux fixes:
* bc8aa6da276f3a2f02cec04595bf27a2636add56. When installing Baballonia (and thus BabbleTrainer) as a system package (or shared user package), it could be that the directory is read-only. We must add extra options to move the temporary storage directory. I've decided to not change default behavior, but that should probably be looked at in the future. I also added one for selecting the baseline dir, to make testing a bit easier.
* 2ff3945a74028a78729557ea8cdc7c0c04199c5a. We should try out if different torch backends are available before forcing CPU.

Torch 2.9.1 changes:
* e437ab64c2ae5ca21cb9473b780231233dd58144. Torch threw warnings.
* f5b26ec75f2e7eae489075d76d97226f155030e8. I needed this to get exporting working on newer Torch.
* 5c0da3da660e4f70f9d6c8ea00a02c57b4e3d170. I'm not sure if  is Windows compatible. `external_data=False`, seems to be a newer Torch feature and DirectML seems to be out-dated.