### PR TITLE
Add basic support for linux cuda and ROCM/HIP devices

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,11 @@ try:
     import torch_directml
     device = torch_directml.device()
 except:
-    device = "cpu"
+    try:
+        import torch.cuda
+        device = torch.device('cuda')
+    except:
+        device = "cpu"
 
 print("Preparing dataset...")
 raw_jpeg_data_left = []


### PR DESCRIPTION
pytorch-rocm ie HIP (ROCm) uses same API as cuda and should work for both assuming you have the correct dependency installed.

This works when running directly from the source but i don't know how to package this so it supports both nvidia and amd in the same binary as on arch at least python-pytorch-cuda and python-pytorch-rocm conflict.

Tested on arch linux with a Radeon RX 7900 XTX 24GB (and an installed RX 5700 XT 8GB but not used for this).