### PR TITLE
Port linux fixes from pull-request #2 to main branch. Fix tmp handling.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-# PyTorch: CPU wheels for non-Windows
-torch==2.6.0+cpu; platform_system != "Windows"
+# PyTorch: for non-Windows
+torch==2.9.1; platform_system != "Windows"
 
 # PyTorch for Windows via DirectML backend
 torch-directml; platform_system == "Windows"

--- a/trainer_distsampler.py
+++ b/trainer_distsampler.py
@@ -1208,6 +1208,16 @@ if __name__ == "__main__":
     from PIL import Image, ImageFile
     from tqdm import tqdm
 
+    class GlobalMaxPool2d(nn.Module):
+        '''
+        Similar to: `nn.AdaptiveMaxPool2d(output_size=1)`
+        '''
+        def __init__(self):
+            super(GlobalMaxPool2d, self).__init__()
+
+        def forward(self, x):
+            return nn.functional.max_pool2d(x, kernel_size=x.size()[2:]) 
+
     class MicroChad(nn.Module):
         def __init__(self, out_count=2):
             super(MicroChad, self).__init__()
@@ -1221,7 +1231,7 @@ if __name__ == "__main__":
             #self.fc_exp = nn.Linear(212, 1)
 
             self.pool = nn.MaxPool2d(kernel_size=2, stride=2, padding=0, dilation=1, ceil_mode=False)
-            self.adaptive = nn.AdaptiveMaxPool2d(output_size=1)
+            self.adaptive = GlobalMaxPool2d()
 
             self.act = nn.ReLU(inplace=True)
             self.sigmoid = nn.Sigmoid()
@@ -1289,7 +1299,7 @@ if __name__ == "__main__":
 
             # --- Define shared, parameter-less layers ---
             self.pool = nn.MaxPool2d(kernel_size=2, stride=2, padding=0)
-            self.adaptive = nn.AdaptiveMaxPool2d(output_size=1)
+            self.adaptive = GlobalMaxPool2d()
             self.act = nn.ReLU(inplace=True)
             self.sigmoid = nn.Sigmoid()
 
@@ -1562,14 +1572,16 @@ if __name__ == "__main__":
             dummy_input,
             sys.argv[2],
             export_params=True,
-            opset_version=15,
+            opset_version=18,
             do_constant_folding=True,
             input_names=['input'],
             output_names=['output'],
             dynamic_axes={
                 'input': {0: 'batch_size'},
                 'output': {0: 'batch_size'}
-            }
+            },
+            dynamo=True,
+            external_data=False
         )
         print("Model exported to ONNX: " + sys.argv[2], flush=True)
 


### PR DESCRIPTION
Based on pull-request https://github.com/Project-Babble/BabbleTrainer/pull/2 by Naraenda. Read through her notes too.
Ported changes to main branch.

New: Uses system provided temporary storage directory for temporary files instead of current directory to support system wide installation.

For most linux'es i think we want to prepend main.py with `#!/usr/bin/env python3` and symlink `BabbleTrainer` to it instead of packaging it up as a single executable. That way the system pytorch will be used which can be the correct flavor for AMD or NVIDIA.
Sadly the file endings need to be unix too and a commit with that shows every line as changed so skipped that.

